### PR TITLE
Add external link for Environment Variables

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -92,8 +92,7 @@ How?
 
 1. Get a personal access token with permission to manage your *gists*
    from `GitHub settings <https://github.com/settings/tokens>`__
-2. Set an environment variable called ``GETGIST_TOKEN`` with your
-   personal access token
+2. Set an `environment variable <https://www.serverlab.ca/tutorials/linux/administration-linux/how-to-set-environment-variables-in-linux/>`__ called                  ``GETGIST_TOKEN`` with your personal access token
 
 Example
 ~~~~~~~


### PR DESCRIPTION
If the user doesn't know how to set Environment Variables that link will be userful